### PR TITLE
fix(package): resolve hanging retry connection timeout by introducing cancelable timeout

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,12 @@
 export function wait(timeInMs) {
-    return new Promise(function(resolve) {
-        return setTimeout(resolve, timeInMs);
+  let timeoutHandle;
+
+  const promise = () => {
+    return new Promise(function (resolve) {
+      timeoutHandle = setTimeout(resolve, timeInMs);
+      return timeoutHandle;
     });
+  };
+
+  return { promise, cancel: () => clearTimeout(timeoutHandle) };
 }


### PR DESCRIPTION
When using this in a Jest test suite, there was an open handle detected. I looked into this and it seems that there is a hanging retry interval even after `.close()` has been called.

I have updated the helper `.wait()` method to be cancelable, meaning that this retry interval can be cancelled.

Heres the code coverage before:
```
=============================== Coverage summary ===============================
Statements   : 97.13% ( 203/209 )
Branches     : 91.94% ( 114/124 )
Functions    : 94.67% ( 71/75 )
Lines        : 97.45% ( 191/196 )
================================================================================
```

Heres the code coverage after:
```
=============================== Coverage summary ===============================
Statements   : 97.27% ( 214/220 )
Branches     : 92.06% ( 116/126 )
Functions    : 94.81% ( 73/77 )
Lines        : 97.56% ( 200/205 )
================================================================================
```

I haven't added any more tests, however this is covered in the existing tests that call `.close()`. (4x)

