### PR TITLE
fix: connection close not awaited

### DIFF
--- a/src/AmqpConnectionManager.js
+++ b/src/AmqpConnectionManager.js
@@ -101,8 +101,12 @@ export default class AmqpConnectionManager extends EventEmitter {
                     this._channels = [];
                     if (this._currentConnection) {
                         this._currentConnection.removeAllListeners('close');
-                        this._currentConnection.close();
+                        return this._currentConnection.close();
+                    } else {
+                        return null;
                     }
+                })
+                .then(() => {
                     this._currentConnection = null;
                 });
         });


### PR DESCRIPTION
The AmqpConnectionManager close promise was resolved before the
underlying connection was fully closed.