### PR TITLE
fix: error when unconfirmed message not found

### DIFF
--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -496,9 +496,7 @@ export default class ChannelWrapper extends EventEmitter {
 
 function removeUnconfirmedMessage(arr, message) {
     const toRemove = arr.indexOf(message);
-    if (toRemove === -1) {
-        throw new Error(`Message is not in _unconfirmedMessages!`);
+    if (toRemove !== -1) {
+        arr.splice(toRemove, 1);
     }
-    const removed = arr.splice(toRemove, 1);
-    return removed[0];
 }


### PR DESCRIPTION
Fixes #152

An error is thrown when a message isn't found in _unconfirmedMessages. I don't have a working example of when it might happen, but when I tested around I could reproduce it with reconnects. This is in line with what michaelfitzhavey's team mates found.

Even if we are unsure how it happens, I think it is fair to say that it is better if it doesn't throw an error, since the error states that the message that we want to remove already is removed =)