### PR TITLE
fix: emit setup errors not caused by closed channel

### DIFF
--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -236,7 +236,7 @@ export default class ChannelWrapper extends EventEmitter {
                     this._setups.map((setupFn) =>
                         // TODO: Use a timeout here to guard against setupFns that never resolve?
                         pb.call(setupFn, this, channel).catch((err) => {
-                            if (err.name === 'IllegalOperationError' && err.message === 'Channel closed') {
+                            if (err.name === 'IllegalOperationError') {
                                 // Don't emit an error if setups failed because the channel closed.
                                 return;
                             }

--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -236,11 +236,11 @@ export default class ChannelWrapper extends EventEmitter {
                     this._setups.map((setupFn) =>
                         // TODO: Use a timeout here to guard against setupFns that never resolve?
                         pb.call(setupFn, this, channel).catch((err) => {
-                            if (this._channel) {
-                                this.emit('error', err, { name: this.name });
-                            } else {
-                                // Don't emit an error if setups failed because the channel was closing.
+                            if (err.name === 'IllegalOperationError' && err.message === 'Channel closed') {
+                                // Don't emit an error if setups failed because the channel closed.
+                                return;
                             }
+                            this.emit('error', err, { name: this.name });
                         })
                     )
                 ).then(() => {

--- a/test/ChannelWrapperTest.js
+++ b/test/ChannelWrapperTest.js
@@ -107,7 +107,9 @@ describe('ChannelWrapper', function () {
 
         const setup2 = sinon.spy(() =>
             promiseTools.delay(20).then(function () {
-                throw new Error('Boom!');
+                const e = new Error('Channel closed');
+                e.name = 'IllegalOperationError';
+                throw e;
             })
         );
 


### PR DESCRIPTION
Fixes #95

The problem is that setup errors like 406 - Precondition failed causes the channel to close and thus no error to be emitted. Those errors will likely continue on each reconnect and ought to be emitted.

Can be tested against real Rabbitmq-server with

```javascript
const { once } = require('events');
let amqp = require('./lib/index');

async function main() {
  let connection = amqp.connect(['amqp://guest:guest@localhost']);
  await once(connection, 'connect');
  console.log('connection connected!');

  let channelWrapper = connection.createChannel({
    setup: async function (channel) {
      await channel.assertQueue('rxQueueName', { durable: true });

      // When channel is closed, no errors will be emitted.
      await channel.close();

      // Uncomment the close line above to cause a 406 Precondition error
      await channel.assertQueue('rxQueueName', { durable: false });
    }
  });

  setTimeout(()=>{
    // We reach here when the reconnect never succeed.
    console.error('connect timeout');
    process.exit(1);
  }, 5e3).unref();

  // No error will be emitted when channel is closed, but will be emitted for
  // e.g. two conflicting assertQueues.
  // Without the fix, no error will ever be emitted.
  await once(channelWrapper, 'connect');
  console.log('connected!');
}
main().then(()=>console.log('Done testing!')).catch(console.error).then(()=>process.exit());
```