### PR TITLE
feat: immediately reconnect on amqplib connect timeout

### DIFF
--- a/src/AmqpConnectionManager.js
+++ b/src/AmqpConnectionManager.js
@@ -208,8 +208,12 @@ export default class AmqpConnectionManager extends EventEmitter {
                 this._currentConnection = null;
                 this._connectPromise = null;
 
-                // TODO: Probably want to try right away here, especially if there are multiple brokers to try...
-                const handle = wait(this.reconnectTimeInSeconds * 1000);
+                let handle;
+                if (err.name === 'OperationalError' && err.message === 'connect ETIMEDOUT') {
+                    handle = wait(0);
+                } else {
+                    handle = wait(this.reconnectTimeInSeconds * 1000);
+                }
                 this._cancelRetriesHandler = handle.cancel;
 
                 return handle.promise().then(() => this._connect());


### PR DESCRIPTION
Since the error is that the connection failed to reconnect in socket timeout time, it is not necessary to wait any further before attempting to reconnect.