### PR TITLE
preserve the publishing order on unexpected disconnection

### DIFF
--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -419,7 +419,7 @@ export default class ChannelWrapper extends EventEmitter {
                         // Tried to write to a closed channel.  Leave the message in the queue and we'll try again when we
                         // reconnect.
                         removeUnconfirmedMessage(this._unconfirmedMessages, message);
-                        this._messages.unshift(message);
+                        this._messages.push(message);
                     } else {
                         // Something went wrong trying to send this message - could be JSON.stringify failed, could be the
                         // broker rejected the message.  Either way, reject it back


### PR DESCRIPTION
Hi!
I found a problem during the reconnection.
The messages are sent in the wrong order causing some inconsistency for example when using AMQP for RPC calls.
To better explain the problem see the following image:

![Notes_210824_162705_1](https://user-images.githubusercontent.com/15072723/130635263-2cbbdcf1-6e26-4f7c-8bc8-9051710178dd.jpg)

This PR solves this problem but I'm not totally sure that the code is order-bulletproof (there may be some edge cases).
Another option would be to store data in an timestamp ordered array but can cause some overhead.

Let me know what you think!
