### PR TITLE
Fixing teardown type

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -218,7 +218,7 @@ export default class ChannelWrapper extends EventEmitter {
      */
     removeSetup(
         setup: SetupFunc,
-        teardown?: pb.Callback<void>,
+        teardown?: SetupFunc,
         done?: pb.Callback<void>
     ): Promise<void> {
         return pb.addCallback(done, () => {


### PR DESCRIPTION
With one of the latest releases - it seems like `teardown` was assigned to the wrong type (update: it always had this wrong type since the migration to TS).

On this line [ChannelWrapper.ts#L228](
https://github.com/jwalton/node-amqp-connection-manager/blob/master/src/ChannelWrapper.ts#L228) the channel is being passed, not the Error. 