### PR TITLE
feat: expose AmqpConnectionManagerClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [3.6.0](https://github.com/jwalton/node-amqp-connection-manager/compare/v3.5.2...v3.6.0) (2021-08-27)
+
+### Features
+
+- reconnect and cancelAll consumers ([fb0c00b](https://github.com/jwalton/node-amqp-connection-manager/commit/fb0c00becc224ffedd28e810cbb314187d21efdb))
+
 ## [3.5.2](https://github.com/jwalton/node-amqp-connection-manager/compare/v3.5.1...v3.5.2) (2021-08-26)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "amqp-connection-manager",
-    "version": "3.5.2",
+    "version": "3.6.0",
     "description": "Auto-reconnect and round robin support for amqplib.",
     "module": "./dist/esm/index.js",
     "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,14 @@ export function connect(
     urls: ConnectionUrl | ConnectionUrl[] | undefined | null,
     options?: AmqpConnectionManagerOptions
 ): IAmqpConnectionManager {
-    return new AmqpConnectionManager(urls, options);
+    const conn = new AmqpConnectionManager(urls, options);
+    conn.connect().catch(() => {
+        /* noop */
+    });
+    return conn;
 }
+
+export { AmqpConnectionManager as AmqpConnectionManagerClass };
 
 const amqp = { connect };
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -146,6 +146,12 @@ export class FakeConfirmChannel extends EventEmitter {
     close = jest.fn().mockImplementation(async (): Promise<void> => {
         this.emit('close');
     });
+
+    consume = jest.fn().mockImplementation(async (): Promise<Replies.Consume> => {
+        return { consumerTag: 'abc' };
+    });
+
+    prefetch = jest.fn().mockImplementation((_prefetch: number, _isGlobal: boolean): void => {});
 }
 
 export class FakeConnection extends EventEmitter {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import { Connection, Message, Options, Replies } from 'amqplib';
-import { EventEmitter } from 'events';
+import { EventEmitter, once } from 'events';
 import { IAmqpConnectionManager } from '../src/AmqpConnectionManager';
 import ChannelWrapper, { CreateChannelOpts } from '../src/ChannelWrapper';
 
@@ -192,6 +192,15 @@ export class FakeAmqpConnectionManager extends EventEmitter implements IAmqpConn
 
     get channelCount(): number {
         return 0;
+    }
+
+    async connect(): Promise<void> {
+        await Promise.all([once(this, 'connect'), this.simulateConnect()]);
+    }
+
+    reconnect(): void {
+        this.simulateDisconnect();
+        this.simulateConnect();
     }
 
     isConnected() {

--- a/test/importTest.ts
+++ b/test/importTest.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
-import amqp from '../src';
+import amqp, { AmqpConnectionManagerClass as AmqpConnectionManager } from '../src';
 
 describe('import test', function () {
     it('should let you import as default (#51)', function () {
         expect(amqp).to.exist;
         expect(amqp.connect).to.exist;
+    });
+
+    it('should let you import class', function () {
+        new AmqpConnectionManager('url');
     });
 });

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -3,7 +3,7 @@ import chai from 'chai';
 import chaiJest from 'chai-jest';
 import pEvent from 'p-event';
 import { defer, timeout } from 'promise-tools';
-import amqp from '../src';
+import amqp, { AmqpConnectionManagerClass as AmqpConnectionManager } from '../src';
 import { IAmqpConnectionManager } from '../src/AmqpConnectionManager';
 
 chai.use(chaiJest);
@@ -67,6 +67,19 @@ describe('Integration tests', () => {
             'amqp://guest:guest@localhost:5672/%2F?heartbeat=10&channelMax=100'
         );
         await timeout(pEvent(connection, 'connect'), 3000);
+    });
+
+    // This test might cause jest to complain about leaked resources due to the bug described and fixed by:
+    // https://github.com/squaremo/amqp.node/pull/584
+    it('should throw on awaited connect with wrong password', async () => {
+        connection = new AmqpConnectionManager('amqp://guest:wrong@localhost');
+        let err;
+        try {
+            await connection.connect();
+        } catch (error) {
+            err = error;
+        }
+        expect(err.message).to.contain('ACCESS-REFUSED');
     });
 
     it('send and receive messages', async () => {


### PR DESCRIPTION
Exposes the underlying class and extracts the connect method
its constructor. The reason for this is that we might want to
initiate the connection later or await its result. With this code
change we can also more easily reject on operational errors and
set a timeout for the initial connect.

The naming is strange because I don't want to introduce any
breaking change.

Note that jest complains about leaking resources due to:
https://github.com/squaremo/amqp.node/pull/584