### PR TITLE
feat: cancel specific consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /npm-debug.log
 /coverage
 /package-lock.json
+/yarn.lock
 /.nyc_output
 /.vscode
 /dist

--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -622,10 +622,9 @@ export default class ChannelWrapper extends EventEmitter {
 
         const cancelConsume = async () => {
             if (this._channel && consumer.consumerTag) {
+                this._consumers = this._consumers.filter((item) => item !== consumer);
                 await this._channel.cancel(consumer.consumerTag);
             }
-
-            this._consumers = this._consumers.filter((item) => item !== consumer);
         };
 
         return cancelConsume;

--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -625,7 +625,7 @@ export default class ChannelWrapper extends EventEmitter {
 
         const { prefetch, ...options } = consumer.options;
         if (typeof prefetch === 'number') {
-            this._channel.prefetch(prefetch, false);
+            await this._channel.prefetch(prefetch, false);
         }
 
         const { consumerTag } = await this._channel.consume(

--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -662,7 +662,7 @@ export default class ChannelWrapper extends EventEmitter {
             },
             options
         );
-        consumer.consumerTag = consumer.options.consumerTag = consumerTag;
+        consumer.consumerTag = consumerTag;
     }
 
     private async _reconnectConsumer(consumer: Consumer): Promise<void> {


### PR DESCRIPTION
Possibility to cancel specific consumer after its setup.

Provides more granularity than `cancelAll` function.

Usage example:
```js
let cancelConsumer = await channel.consume(queueName, (msg) => {
    //your code
}, { prefetch: 10 });

await cancelConsumer()

cancelConsumer = await channel.consume(queueName, (msg) => {
    //your code
}, { prefetch: 100 });

process.on('SIGTERM', () => cancelConsumer())
```

This PR also:
- includes `await` when prefetch is setted up