### PR TITLE
feat: proxying every exchange function of amqplib

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -837,6 +837,57 @@ export default class ChannelWrapper extends EventEmitter {
         }
     }
 
+    /** Send a `bindExchange` to the underlying channel. */
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    async bindExchange(
+        destination: string,
+        source: string,
+        pattern: string,
+        args?: any
+    ): Promise<amqplib.Replies.Empty> {
+        if (this._channel) {
+            return await this._channel.bindExchange(destination, source, pattern, args);
+        } else {
+            throw new Error(`Not connected.`);
+        }
+    }
+
+    /** Send a `checkExchange` to the underlying channel. */
+    async checkExchange(exchange: string): Promise<amqplib.Replies.Empty> {
+        if (this._channel) {
+            return await this._channel.checkExchange(exchange);
+        } else {
+            throw new Error(`Not connected.`);
+        }
+    }
+
+    /** Send a `deleteExchange` to the underlying channel. */
+    async deleteExchange(
+        exchange: string,
+        options?: Options.DeleteExchange
+    ): Promise<amqplib.Replies.Empty> {
+        if (this._channel) {
+            return await this._channel.deleteExchange(exchange, options);
+        } else {
+            throw new Error(`Not connected.`);
+        }
+    }
+
+    /** Send a `unbindExchange` to the underlying channel. */
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    async unbindExchange(
+        destination: string,
+        source: string,
+        pattern: string,
+        args?: any
+    ): Promise<amqplib.Replies.Empty> {
+        if (this._channel) {
+            return await this._channel.unbindExchange(destination, source, pattern, args);
+        } else {
+            throw new Error(`Not connected.`);
+        }
+    }
+
     /** Send a `get` to the underlying channel. */
     async get(queue: string, options?: Options.Get): Promise<amqplib.GetMessage | false> {
         if (this._channel) {

--- a/test/ChannelWrapperTest.ts
+++ b/test/ChannelWrapperTest.ts
@@ -538,7 +538,7 @@ describe('ChannelWrapper', function () {
         return channelWrapper.nack(makeMessage('c'), false, true);
     });
 
-    it('should proxy assertQueue, bindQueue, assertExchange to the underlying channel', function () {
+    it('should proxy assertQueue, checkQueue, bindQueue, assertExchange, checkExchange to the underlying channel', function () {
         connectionManager.simulateConnect();
         const channelWrapper = new ChannelWrapper(connectionManager);
         return channelWrapper.waitForConnect().then(function () {
@@ -549,6 +549,10 @@ describe('ChannelWrapper', function () {
             expect(channel.assertQueue).to.have.beenCalledTimes(1);
             expect(channel.assertQueue).to.have.beenCalledWith('dog', undefined);
 
+            channelWrapper.checkQueue('cat');
+            expect(channel.checkQueue).to.have.beenCalledTimes(1);
+            expect(channel.checkQueue).to.have.beenCalledWith('cat');
+
             channelWrapper.bindQueue('dog', 'bone', '.*');
             expect(channel.bindQueue).to.have.beenCalledTimes(1);
             expect(channel.bindQueue).to.have.beenCalledWith('dog', 'bone', '.*', undefined);
@@ -556,6 +560,10 @@ describe('ChannelWrapper', function () {
             channelWrapper.assertExchange('bone', 'topic');
             expect(channel.assertExchange).to.have.beenCalledTimes(1);
             expect(channel.assertExchange).to.have.beenCalledWith('bone', 'topic', undefined);
+
+            channelWrapper.checkExchange('fish');
+            expect(channel.checkExchange).to.have.beenCalledTimes(1);
+            expect(channel.checkExchange).to.have.beenCalledWith('fish');
         });
     });
 
@@ -588,6 +596,32 @@ describe('ChannelWrapper', function () {
         channelWrapper.assertQueue('dog', { durable: true });
         channelWrapper.bindQueue('dog', 'bone', '.*');
         channelWrapper.assertExchange('bone', 'topic');
+    });
+
+    it('should proxy bindExchange, unbindExchange and deleteExchange to the underlying channel', function () {
+        connectionManager.simulateConnect();
+        const channelWrapper = new ChannelWrapper(connectionManager);
+        return channelWrapper.waitForConnect().then(function () {
+            // get the underlying channel
+            const channel = getUnderlyingChannel(channelWrapper);
+
+            channelWrapper.bindExchange('paris', 'london', '*');
+            expect(channel.bindExchange).to.have.beenCalledTimes(1);
+            expect(channel.bindExchange).to.have.beenCalledWith('paris', 'london', '*', undefined);
+
+            channelWrapper.unbindExchange('paris', 'london', '*');
+            expect(channel.unbindExchange).to.have.beenCalledTimes(1);
+            expect(channel.unbindExchange).to.have.beenCalledWith(
+                'paris',
+                'london',
+                '*',
+                undefined
+            );
+
+            channelWrapper.deleteExchange('chicago');
+            expect(channel.deleteExchange).to.have.beenCalledTimes(1);
+            expect(channel.deleteExchange).to.have.beenCalledWith('chicago', undefined);
+        });
     });
 
     // Not much to test here - just make sure we don't throw any exceptions or anything weird.  :)

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -122,6 +122,12 @@ export class FakeConfirmChannel extends EventEmitter {
             };
         });
 
+    checkQueue = jest
+        .fn()
+        .mockImplementation(async function (_queue: string): Promise<Replies.Empty> {
+            return {};
+        });
+
     bindQueue = jest
         .fn()
         .mockImplementation(async function (
@@ -141,6 +147,43 @@ export class FakeConfirmChannel extends EventEmitter {
             _options?: Options.AssertExchange
         ): Promise<Replies.AssertExchange> {
             return { exchange };
+        });
+
+    bindExchange = jest
+        .fn()
+        .mockImplementation(async function (
+            _destination: string,
+            _source: string,
+            _pattern: string,
+            _args?: any
+        ): Promise<Replies.Empty> {
+            return {};
+        });
+
+    checkExchange = jest
+        .fn()
+        .mockImplementation(async function (_exchange: string): Promise<Replies.Empty> {
+            return {};
+        });
+
+    deleteExchange = jest
+        .fn()
+        .mockImplementation(async function (
+            _exchange: string,
+            _options?: Options.DeleteExchange
+        ): Promise<Replies.Empty> {
+            return {};
+        });
+
+    unbindExchange = jest
+        .fn()
+        .mockImplementation(async function (
+            _destination: string,
+            _source: string,
+            _pattern: string,
+            _args?: any
+        ): Promise<Replies.Empty> {
+            return {};
         });
 
     close = jest.fn().mockImplementation(async (): Promise<void> => {


### PR DESCRIPTION
bindExchange, checkExchange, deleteExchange and unbindExchange were missing in ChannelWrapper.