### PR TITLE
fix: Emit `connectFailed` on connection failure.

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -1,16 +1,21 @@
 name: GitHub CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags:
+      - '*'
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x, 16.x, 'lts/*']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: docker-compose up -d
@@ -40,9 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 'lts/*'
       - run: npm install
       - name: semantic-release
         run: npm run semantic-release

--- a/README.md
+++ b/README.md
@@ -146,10 +146,6 @@ Returns true if the AmqpConnectionManager is connected to a broker, false otherw
 
 Close this AmqpConnectionManager and free all associated resources.
 
-### AmqpConnectionManager#connectionAttempts
-
-This is the number of times we've tried to connect to a broker.
-
 ### ChannelWrapper events
 
 - `connect` - emitted every time this channel connects or reconnects.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Options:
 - `options.reconnectTimeInSeconds` - The time to wait before trying to reconnect. If not specified,
   defaults to `heartbeatIntervalInSeconds`.
 - `options.findServers(callback)` is a function which returns one or more servers to connect to. This should
-  return either a single URL or an array of URLs. This is handy when you're using a service discovery mechanism
+  return either a single URL or an array of URLs. This is handy when you're using a service discovery mechanism.
   such as Consul or etcd. Instead of taking a `callback`, this can also return a Promise. Note that if this
   is supplied, then `urls` is ignored.
 - `options.connectionOptions` is passed as options to the amqplib connect method.
@@ -114,6 +114,7 @@ Options:
 ### AmqpConnectionManager events
 
 - `connect({connection, url})` - Emitted whenever we successfully connect to a broker.
+- `connectFailed({err, url})` - Emitted whenever we attempt to connect to a broker, but fail.
 - `disconnect({err})` - Emitted whenever we disconnect from a broker.
 - `blocked({reason})` - Emitted whenever a connection is blocked by a broker
 - `unblocked` - Emitted whenever a connection is unblocked by a broker
@@ -144,6 +145,10 @@ Returns true if the AmqpConnectionManager is connected to a broker, false otherw
 ### AmqpConnectionManager#close()
 
 Close this AmqpConnectionManager and free all associated resources.
+
+### AmqpConnectionManager#connectionAttempts
+
+This is the number of times we've tried to connect to a broker.
 
 ### ChannelWrapper events
 

--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -157,16 +157,6 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
     public heartbeatIntervalInSeconds: number;
     public reconnectTimeInSeconds: number;
 
-    private _connectionAttempts = 0;
-
-    /**
-     * The number of connection attempts this connection manager has made,
-     * successful, failed, or in-progress..
-     */
-    get connectionAttempts(): number {
-        return this._connectionAttempts;
-    }
-
     /**
      *  Create a new AmqplibConnectionManager.
      *
@@ -338,8 +328,6 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
         if (this._closed || this.isConnected()) {
             return Promise.resolve(null);
         }
-
-        this._connectionAttempts++;
 
         let attemptedUrl: string | amqp.Options.Connect | undefined;
 

--- a/test/AmqpConnectionManagerTest.ts
+++ b/test/AmqpConnectionManagerTest.ts
@@ -151,10 +151,10 @@ describe('AmqpConnectionManager', function () {
                 return Promise.resolve(null);
             },
         });
+
         amqp.connect();
         const [{ err }] = await once(amqp, 'connectFailed');
         expect(err.message).to.contain('No servers found');
-        expect(amqp.connectionAttempts).to.equal(1);
         return amqp?.close();
     });
 
@@ -204,7 +204,6 @@ describe('AmqpConnectionManager', function () {
 
         const [{ connection, url }] = await once(amqp, 'connect');
         expect(connectFailedSeen).to.equal(1);
-        expect(amqp.connectionAttempts).to.equal(2);
 
         // Verify that we round-robined to the next server, since the first was unavailable.
         expect(url, 'url').to.equal('amqp://rabbit2');

--- a/test/AmqpConnectionManagerTest.ts
+++ b/test/AmqpConnectionManagerTest.ts
@@ -152,8 +152,9 @@ describe('AmqpConnectionManager', function () {
             },
         });
         amqp.connect();
-        const [{ err }] = await once(amqp, 'disconnect');
+        const [{ err }] = await once(amqp, 'connectFailed');
         expect(err.message).to.contain('No servers found');
+        expect(amqp.connectionAttempts).to.equal(1);
         return amqp?.close();
     });
 
@@ -189,22 +190,23 @@ describe('AmqpConnectionManager', function () {
     it("should reconnect to the broker if it can't connect in the first place", async () => {
         amqplib.deadServers = ['amqp://rabbit1'];
 
-        // Should try to connect to rabbit1 first and be refused, and then succesfully connect to rabbit2.
+        // Should try to connect to rabbit1 first and be refused, and then successfully connect to rabbit2.
         amqp = new AmqpConnectionManager(['amqp://rabbit1', 'amqp://rabbit2'], {
             heartbeatIntervalInSeconds: 0.01,
         });
         amqp.connect();
 
-        let disconnectEventsSeen = 0;
-        amqp.on('disconnect', function () {
-            disconnectEventsSeen++;
+        let connectFailedSeen = 0;
+        amqp.on('connectFailed', function () {
+            connectFailedSeen++;
             amqplib.failConnections = false;
         });
 
         const [{ connection, url }] = await once(amqp, 'connect');
-        expect(disconnectEventsSeen).to.equal(1);
+        expect(connectFailedSeen).to.equal(1);
+        expect(amqp.connectionAttempts).to.equal(2);
 
-        // Verify that we round-robined to the next server, since the first was unavilable.
+        // Verify that we round-robined to the next server, since the first was unavailable.
         expect(url, 'url').to.equal('amqp://rabbit2');
         if (typeof url !== 'string') {
             throw new Error('url is not a string');


### PR DESCRIPTION
Fixes #222.

This makes it so instead of emitting a `disconnect` event the first time we fail to connect, AmqpConnectionManager now emits a `connectFailed`.  AmqpConnectionManager emits `connectFailed` on every connection failure, and emits `disconnect` only when we transition from connected to disconnected.

BREAKING CHANGE: We will no longer emit a `disconnect` event on an
initial connection failure - instead we now emit `connectFailed` on each
connection failure, and only emit `disconnect` when we transition from
connected to disconnected.