### PR TITLE
fix: accept type of amqplib.credentials.external()

### DIFF
--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -36,6 +36,10 @@ export type AmpqConnectionOptions = (ConnectionOptions | TcpSocketConnectOpts) &
               password: string;
               response: () => Buffer;
           }
+        | {
+              mechanism: string;
+              response: () => Buffer;
+          }
         | undefined;
 };
 


### PR DESCRIPTION
`amqplib.credentials.external()` [does not contain](https://github.com/amqp-node/amqplib/blob/main/lib/credentials.js#L37-L42) a `username` or `password`, so a new accepted type has been added.

also mentioned in https://github.com/jwalton/node-amqp-connection-manager/issues/137#issuecomment-784494262