### PR TITLE
fix: accept 0 for heartbeatIntervalInSeconds

### DIFF
--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -198,7 +198,9 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
         this.connectionOptions = options.connectionOptions;
 
         this.heartbeatIntervalInSeconds =
-            options.heartbeatIntervalInSeconds || HEARTBEAT_IN_SECONDS;
+            options.heartbeatIntervalInSeconds || options.heartbeatIntervalInSeconds === 0
+                ? options.heartbeatIntervalInSeconds
+                : HEARTBEAT_IN_SECONDS;
         this.reconnectTimeInSeconds =
             options.reconnectTimeInSeconds || this.heartbeatIntervalInSeconds;
 

--- a/test/AmqpConnectionManagerTest.ts
+++ b/test/AmqpConnectionManagerTest.ts
@@ -59,6 +59,16 @@ describe('AmqpConnectionManager', function () {
         expect(connection.url, 'connection.url').to.equal('amqp://localhost?heartbeat=5');
     });
 
+    it('should establish a connection to a broker disabling heartbeat', async () => {
+        amqp = new AmqpConnectionManager('amqp://localhost', {
+            heartbeatIntervalInSeconds: 0,
+        });
+        amqp.connect();
+        const [{ connection, url }] = await once(amqp, 'connect');
+        expect(url, 'url').to.equal('amqp://localhost');
+        expect(connection.url, 'connection.url').to.equal('amqp://localhost?heartbeat=0');
+    });
+
     it('should close connection to a broker', async () => {
         amqp = new AmqpConnectionManager('amqp://localhost');
         amqp.connect();


### PR DESCRIPTION
CloudAMQP recommend turning heartbeats off https://www.cloudamqp.com/docs/faq.html#closing-amqp-connection-error-heartbeattimeout.
amqplib also accept 0 for heartbeat parameter https://amqp-node.github.io/amqplib/channel_api.html#heartbeating