### PR TITLE
Export ChannelWrapper class, not only as a type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,10 @@ export type {
 } from './AmqpConnectionManager.js';
 export type {
     CreateChannelOpts,
-    default as ChannelWrapper,
     SetupFunc,
     Channel,
 } from './ChannelWrapper.js';
+export { default as ChannelWrapper } from './ChannelWrapper.js';
 
 import { Options as AmqpLibOptions } from 'amqplib';
 


### PR DESCRIPTION
The facto that `ChannelWrapper` is forcefully being exported as a type-only is causing issue with Dependency Injection in Nest, which uses decorators.