### PR TITLE
fix: consumer registered twice during setup

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -733,6 +733,11 @@ export default class ChannelWrapper extends EventEmitter {
                 consumerTag,
             },
         };
+
+        if (this._settingUp) {
+            await this._settingUp;
+        }
+
         this._consumers.push(consumer);
         await this._consume(consumer);
         return { consumerTag };

--- a/test/ChannelWrapperTest.ts
+++ b/test/ChannelWrapperTest.ts
@@ -1283,6 +1283,20 @@ describe('ChannelWrapper', function () {
         expect(queue2).to.deep.equal([1]);
         expect(canceledTags).to.deep.equal(['1', '2']);
     });
+
+    it('should not register same consumer twice', async function () {
+        const setup = jest.fn().mockImplementation(() => promiseTools.delay(10));
+
+        const channelWrapper = new ChannelWrapper(connectionManager, { setup });
+        connectionManager.simulateConnect();
+
+        await channelWrapper.consume('queue', () => {});
+
+        await channelWrapper.waitForConnect();
+
+        const channel = getUnderlyingChannel(channelWrapper);
+        expect(channel.consume).to.have.beenCalledTimes(1);
+    });
 });
 
 /** Returns the arguments of the most recent call to this mock. */


### PR DESCRIPTION
Fixes #297

If consume is called before the setup function is completed, the same consumer can be registered twice and cause a precondition error.