### PR TITLE
fix: Fail immediately for a bad password on latest amqplib.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@types/whatwg-url": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
-        "amqplib": "^0.8.0",
+        "amqplib": "^0.10.3",
         "chai": "^4.1.2",
         "chai-as-promised": "^7.1.1",
         "chai-jest": "^1.0.2",

--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -220,9 +220,9 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
         this._connect();
 
         let reject: (reason?: any) => void;
-        const onConnectFailed = ({ err }: { err: any }) => {
-            // Ignore disconnects caused by dead servers etc., but throw on operational errors like bad credentials.
-            if (err.isOperational) {
+        const onConnectFailed = ({ err }: { err: Error }) => {
+            // Ignore disconnects caused bad credentials.
+            if (err.message.includes('ACCESS-REFUSED') || err.message.includes('403')) {
                 reject(err);
             }
         };


### PR DESCRIPTION
Related to https://github.com/jwalton/node-amqp-connection-manager/pull/303, it looks like now amqplib no longer has an `isOperational` flag on errors anymore.  It looks like this was a BlueBird thing, and amqplib switch to native promises so it was removed.

We used to fail immediately with a reject when trying to connect with a bad password, but because of the missing `isOperational` flag we don't anymore.  I fix this, and verified it on amqplib v0.8.0, then bumped the development version of amqplib to v0.10.3.