### PR TITLE
fix: exporting ChannelWrapper as a type without it getting emitted as metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,15 @@ import AmqpConnectionManager, {
     ConnectionUrl,
     IAmqpConnectionManager,
 } from './AmqpConnectionManager.js';
-import { PublishOptions } from './ChannelWrapper.js';
+import CW, { PublishOptions } from './ChannelWrapper.js';
 
 export type {
     AmqpConnectionManagerOptions,
     ConnectionUrl,
     IAmqpConnectionManager as AmqpConnectionManager,
 } from './AmqpConnectionManager.js';
-export type {
-    CreateChannelOpts,
-    default as ChannelWrapper,
-    SetupFunc,
-    Channel,
-} from './ChannelWrapper.js';
+export type { CreateChannelOpts, SetupFunc, Channel } from './ChannelWrapper.js';
+export type ChannelWrapper = CW;
 
 import { Options as AmqpLibOptions } from 'amqplib';
 


### PR DESCRIPTION
Fix that prevents Typescript from accidentally exposing `ChannelWrapper` as a class in emitted metadata(`emitDecoratorMetadata`).

Fixes #305, related to #249.