### PR TITLE
refactor: export Consumer and ConsumerOptions

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -69,11 +69,11 @@ export interface PublishOptions extends Options.Publish {
     timeout?: number;
 }
 
-interface ConsumerOptions extends amqplib.Options.Consume {
+export interface ConsumerOptions extends amqplib.Options.Consume {
     prefetch?: number;
 }
 
-interface Consumer {
+export interface Consumer {
     consumerTag: string | null;
     queue: string;
     onMessage: (msg: amqplib.ConsumeMessage) => void;


### PR DESCRIPTION
Not sure if this was intentional or not, but exposing the interfaces makes it cleaner to implement a passthrough method like

`myConsumeMessagesMethod(consumptionFunction: Consumer["onMessage"], options?: ConsumerOptions):Promise<void>`