### PR TITLE
fix: export types in separate directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
     "description": "Auto-reconnect and round robin support for amqplib.",
     "module": "./dist/esm/index.js",
     "main": "./dist/cjs/index.js",
-    "types": "./dist/esm/index.d.ts",
+    "types": "./dist/types/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
+            "types": "./dist/types/index.d.ts",
             "import": "./dist/esm/index.js",
             "require": "./dist/cjs/index.js",
             "default": "./dist/cjs/index.js"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "scripts": {
         "prepare": "husky install && npm run build",
         "prepublishOnly": "npm run build",
-        "build": "tsc && tsc -p tsconfig.cjs.json && ./bin/build-types.sh",
+        "build": "tsc && tsc -p tsconfig.cjs.json && tsc -p tsconfig.types.json && ./bin/build-types.sh",
         "clean": "rm -rf dist types coverage",
         "test": "npm run test:lint && npm run test:unittest",
         "test:unittest": "tsc -p test && jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "lib": ["es2018"],
         "allowJs": false,
         // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-        "declaration": true,
+        "declaration": false,
         "sourceMap": true,
         "outDir": "./dist/esm",
         "stripInternal": true,

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "./dist/types"
+    }
+}


### PR DESCRIPTION
When using `node16` or `nodenext` for `module` in `tsconfig.json` in combination with `commonjs` for `type` in `package.json`(which is also the default) Typescript will throw an error. This is because Typescript mark it as a ES module due to the closest `package.json` for the types being the one with `type` set to `module`. By exporting the types in a separate folder the issue is resolved.

Also it might be nice to introduce [`concurrently`](https://www.npmjs.com/package/concurrently) for the build process, so the compilation happens in parallel.
```json
"build": "concurrently  'tsc' 'tsc -p tsconfig.cjs.json' 'tsc -p tsconfig.types.json' && ./bin/build-types.sh",
```