### PR TITLE
feat: added new function: findChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ depending on whether or not we are currently connected.)
 
 Options:
 
-- `options.name` - Name for this channel. Used for debugging.
+- `options.name` - Name for this channel. Used as the index of a channel or for debugging purposes.
 - `options.setup(channel, [cb])` - A function to call whenever we reconnect to the
   broker (and therefore create a new underlying channel.) This function should
   either accept a callback, or return a Promise. See `addSetup` below.
@@ -137,6 +137,29 @@ Options:
   are plain JSON objects. These will be encoded automatically before being sent.
 - `options.confirm` - if true (default), the created channel will be a ConfirmChannel
 - `options.publishTimeout` - a default timeout for messages published to this channel.
+
+### AmqpConnectionManager#findChannel(name)
+
+Finds the channel that has already been created.
+If the channel does not exist, we will return 'undefined'.
+It turns an instance of ChannelWrapper object.
+
+The `name` property has to be included during creation of the channel so it can be found.:
+
+```js
+var QUEUE_NAME = 'amqp-connection-manager-find-channel';
+
+connection.createChannel({
+  name: QUEUE_NAME,
+  json: true,
+  setup: function (channel) {
+    // `channel` here is a regular amqplib `ConfirmChannel`.
+    return channel.assertQueue(QUEUE_NAME, { durable: true });
+  },
+});
+
+var channelWrapper = connection.findChannel(QUEUE_NAME);
+```
 
 ### AmqpConnectionManager#isConnected()
 

--- a/examples/find-channel.js
+++ b/examples/find-channel.js
@@ -1,0 +1,43 @@
+var amqp = require('..');
+
+var QUEUE_NAME = 'amqp-connection-manager-find-channel';
+
+// Create a connetion manager
+var connection = amqp.connect(['amqp://localhost']);
+connection.on('connect', function () {
+    console.log('Connected!');
+});
+connection.on('disconnect', function (err) {
+    console.log('Disconnected.', err.stack);
+});
+
+// Create a channel wrapper
+connection.createChannel({
+    json: true,
+    setup: function (channel) {
+        // `channel` here is a regular amqplib `ConfirmChannel`.
+        return channel.assertQueue(QUEUE_NAME, { durable: true });
+    },
+});
+
+var channelWrapper = connection.findChannel(QUEUE_NAME);
+
+// Send messages until someone hits CTRL-C or something goes wrong...
+var sendMessage = function () {
+    channelWrapper
+        .sendToQueue(QUEUE_NAME, { time: Date.now() })
+        .then(function () {
+            console.log('Message sent');
+        })
+        .then(function () {
+            return sendMessage();
+        })
+        .catch(function (err) {
+            console.log('Message was rejected:', err.stack);
+            channelWrapper.close();
+            connection.close();
+        });
+};
+
+console.log('Sending messages...');
+sendMessage();

--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -127,6 +127,7 @@ export interface IAmqpConnectionManager {
     connect(options?: { timeout?: number }): Promise<void>;
     reconnect(): void;
     createChannel(options?: CreateChannelOpts): ChannelWrapper;
+    findChannel(name: string): ChannelWrapper | undefined;
     close(): Promise<void>;
     isConnected(): boolean;
 
@@ -260,6 +261,10 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
             this._channels = this._channels.filter((c) => c !== channel);
         });
         return channel;
+    }
+
+    findChannel(name: string): ChannelWrapper | undefined {
+        return this._channels.find((obj) => obj.name === name) || undefined;
     }
 
     close(): Promise<void> {

--- a/test/AmqpConnectionManagerTest.ts
+++ b/test/AmqpConnectionManagerTest.ts
@@ -298,6 +298,19 @@ describe('AmqpConnectionManager', function () {
         expect(amqp.listeners('disconnect').length, 'disconnect listners after close').to.equal(0);
     });
 
+    it('should create and be able to find channel', async function () {
+        amqp = new AmqpConnectionManager('amqp://localhost');
+        await amqp.connect();
+        const channel = amqp.createChannel({ name: 'test-chan' });
+        const findChannel = amqp.findChannel('test-chan');
+        // Channel should register with connection manager
+        expect(amqp.channelCount, 'registered channels').to.equal(1);
+        expect(channel, 'same channe').to.equal(findChannel);
+
+        // Closing the channel should remove all listeners and de-register the channel
+        await channel.close();
+    });
+
     it('should clean up channels on close', async function () {
         amqp = new AmqpConnectionManager('amqp://localhost');
         await amqp.connect();


### PR DESCRIPTION
So... a while back I wrote a plugin for [fastify](https://fastify.dev) using this package as a template to quickly be part of the [fastify](https://fastify.dev) eco-system. 

So I been working on a re-write of my plugin and while you can search _channels in my "decorator" this seem crazy to have to do it each time and there was no way to index the channels or "find" the correct one. I tried to write it in my code and keep everything afloat. But it did not work.

So this evening I wrote up a  ```findChannel``` function and from the example and updated docs, as long as "name" is used during creation, a user could find and get back the ChannelWrappter object of the correct channel and do what you wanted to do with it.

I hope you enjoy this!