### PR TITLE
Add expiration publish option

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -67,6 +67,9 @@ interface SendToQueueMessage {
 export interface PublishOptions extends Options.Publish {
     /** Message will be rejected after timeout ms */
     timeout?: number;
+    
+    /** Message will be discarded from a queue after expiration ms */
+    expiration?: number;
 }
 
 export interface ConsumerOptions extends amqplib.Options.Consume {


### PR DESCRIPTION
RabbitMQ support the expiration option, which automatically removes a message from the queue after the given number of milliseconds.