### PR TITLE
Align `connection` type with upstream amqplib types

### DIFF
--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -131,7 +131,7 @@ export interface IAmqpConnectionManager {
     isConnected(): boolean;
 
     /** The current connection. */
-    readonly connection: amqp.Connection | undefined;
+    readonly connection: amqp.ChannelModel | undefined;
 
     /** Returns the number of registered channels. */
     readonly channelCount: number;


### PR DESCRIPTION
to align with changes made in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72093/files#diff-1a27f7fd828ae4ba14a367d7e714fb536693dd1ebf63e31b5f62da7338fc425e

I don't know how it should be in terms of versions here, because it is breaking on types, but it was not a major version on the amqplib types.
Anyway, without this change types are now completely broken